### PR TITLE
fix source componentId

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -24,7 +24,7 @@ class Config extends BaseConfig
 
     public function getSourceComponentId(): string
     {
-        switch ((string) getenv('KBC_URL')) {
+        switch ($this->getSourceProjectUrl()) {
             case 'connection.north-europe.azure.keboola.com':
                 return self::AZURE_COMPONENT_ID;
             default:


### PR DESCRIPTION
https://keboola.slack.com/archives/C09U3R1J4/p1622552860010500

zdrojové id komponenty se musí brát podle zdrojové url Kebooly